### PR TITLE
Add sleep before running to allow Parseable to start

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -35,6 +35,7 @@ run_load_test () {
   return $?
 }
 
+sleep 20
 case "$mode" in
    "smoke") run_smoke_test 
    ;;


### PR DESCRIPTION
This is needed in case of Docker Compose based CI tests that are run in Parseable repo per PR.