### PR TITLE
feat: add test coverage for hot tier

### DIFF
--- a/quest_test.go
+++ b/quest_test.go
@@ -441,8 +441,16 @@ func TestHotTierGetsLogsAfter(t *testing.T) {
 	DeleteStream(t, NewGlob.QueryClient, NewGlob.Stream)
 }
 
+// create stream, ingest data, query get count, set hot tier, wait for 2-3 mins, query again get count, both counts should match
 func TestHotTierLogCount(t *testing.T) {
-	// create stream, ingest data, query get count, set hot tier, wait for 2-3 mins, query again get count, both counts should match
+	createAndIngest(t)
+	countBefore := QueryLogStreamCount(t, NewGlob.QueryClient, NewGlob.Stream, 50)
+
+	activateHotTier(t)
+	time.Sleep(60 * 2 * time.Second) // wait for 2 minutes to allow hot tier to sync
+
+	countAfter := QueryLogStreamCount(t, NewGlob.QueryClient, NewGlob.Stream, 50)
+	require.Equalf(t, countBefore, countAfter, "Ingested %s, but hot tier contains only %s", countBefore, countAfter)
 }
 
 func TestOldestHotTierEntry(t *testing.T) {

--- a/quest_test.go
+++ b/quest_test.go
@@ -34,13 +34,6 @@ const (
 	events_count = "5"
 )
 
-type StreamHotTier struct {
-	Size                string  `json:"size"`
-	UsedSize            *string `json:"used_size,omitempty"`
-	AvailableSize       *string `json:"available_size,omitempty"`
-	OldestDateTimeEntry *string `json:"oldest_date_time_entry,omitempty"`
-}
-
 func TestSmokeListLogStream(t *testing.T) {
 	CreateStream(t, NewGlob.QueryClient, NewGlob.Stream)
 	req, err := NewGlob.QueryClient.NewRequest("GET", "logstream", nil)

--- a/quest_test.go
+++ b/quest_test.go
@@ -428,8 +428,14 @@ func TestHotTierGetsLogsAfter(t *testing.T) {
 	body, err := readJsonBody[StreamHotTier](response.Body)
 	require.NoErrorf(t, err, "Hot tier response not in correct schema: %s", err)
 
+	// get total byte count of ingested logs
+	size := 0
+	for _, expectedlog := range logs {
+		size = size + int(expectedlog.ByteCount)
+	}
+
 	// ascertain that the ingested all the ingested logs are present in hot tier
-	require.Equalf(t, len(logs), "%d", body.Size, "Total no. of ingested logs is %d but hot tier contains %d logs", len(logs), body.Size)
+	require.Equalf(t, size, "%d", *body.UsedSize, "Total size of ingested logs is %d GiB but hot tier contains %d GiB", size, body.UsedSize)
 
 	disableHotTier(t)
 	DeleteStream(t, NewGlob.QueryClient, NewGlob.Stream)

--- a/quest_test.go
+++ b/quest_test.go
@@ -409,11 +409,23 @@ func TestSmokeGetRetention(t *testing.T) {
 	DeleteStream(t, NewGlob.QueryClient, NewGlob.Stream)
 }
 
-func TestHotTierGetsLogs(t *testing.T) {
-	// create stream, put hot tier, ingest data for a duration, wait for 2-3 mins to see if all data is available in hot tier
+func TestActivateHotTier(t *testing.T) {
+	activateHotTier(t)
 }
 
+func TestHotTierGetsLogs(t *testing.T) {
+	// create stream, put hot tier, ingest data for a duration, wait for 2-3 mins to see if all data is available in hot tier
+	if NewGlob.IngestorUrl.String() == "" {
+		t.Skip("Skipping in standalone mode")
+	}
+}
+
+// create stream, ingest data for a duration, set hot tier, wait for 2-3 mins to see if all data is available in hot tier
 func TestHotTierGetsLogsAfter(t *testing.T) {
+	if NewGlob.IngestorUrl.String() == "" {
+		t.Skip("Skipping in standalone mode")
+	}
+
 	logs := createAndIngest(t)
 
 	activateHotTier(t)
@@ -443,6 +455,10 @@ func TestHotTierGetsLogsAfter(t *testing.T) {
 
 // create stream, ingest data, query get count, set hot tier, wait for 2-3 mins, query again get count, both counts should match
 func TestHotTierLogCount(t *testing.T) {
+	if NewGlob.IngestorUrl.String() == "" {
+		t.Skip("Skipping in standalone mode")
+	}
+
 	createAndIngest(t)
 	countBefore := QueryLogStreamCount(t, NewGlob.QueryClient, NewGlob.Stream, 50)
 
@@ -455,6 +471,9 @@ func TestHotTierLogCount(t *testing.T) {
 
 func TestOldestHotTierEntry(t *testing.T) {
 	// create stream, ingest data for a duration, call GET /logstream/{logstream}/info - to get the first_event_at field then set hot tier, wait for 2-3 mins, call GET /hottier - to get oldest entry in hot tier then match both
+	if NewGlob.IngestorUrl.String() == "" {
+		t.Skip("Skipping in standalone mode")
+	}
 }
 
 // This test calls all the User API endpoints

--- a/test_utils.go
+++ b/test_utils.go
@@ -561,3 +561,19 @@ func checkAPIAccess(t *testing.T, client HTTPClient, stream string, role string)
 		require.Equalf(t, 403, response.StatusCode, "Server returned http code: %s and response: %s", response.Status, readAsString(response.Body))
 	}
 }
+
+func activateHotTier(t *testing.T) {
+	req, _ := NewGlob.QueryClient.NewRequest("PUT", "logstream/"+NewGlob.Stream+"/hottier", nil)
+	response, err := NewGlob.QueryClient.Do(req)
+	body := readAsString(response.Body)
+	require.Equalf(t, 200, response.StatusCode, "Server returned http code: %s and response: %s", response.Status, body)
+	require.NoErrorf(t, err, "Activating hot tier failed: %s", err)
+}
+
+func disableHotTier(t *testing.T) {
+	req, _ := NewGlob.QueryClient.NewRequest("PUT", "logstream/"+NewGlob.Stream+"/hottier", nil)
+	response, err := NewGlob.QueryClient.Do(req)
+	body := readAsString(response.Body)
+	require.Equalf(t, 200, response.StatusCode, "Server returned http code: %s and response: %s", response.Status, body)
+	require.NoErrorf(t, err, "Disabling hot tier failed: %s", err)
+}

--- a/test_utils.go
+++ b/test_utils.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"os/exec"
 	"strings"
 	"testing"
@@ -76,8 +75,9 @@ func Sleep() {
 func CreateStream(t *testing.T, client HTTPClient, stream string) {
 	req, _ := client.NewRequest("PUT", "logstream/"+stream, nil)
 	response, err := client.Do(req)
+	body := readAsString(response.Body)
 	require.NoErrorf(t, err, "Request failed: %s", err)
-	require.Equalf(t, 200, response.StatusCode, "Server returned http code: %s", response.Status)
+	require.Equalf(t, 200, response.StatusCode, "Server returned http code: %s with response: %s", response.Status, body)
 }
 
 func CreateStreamWithHeader(t *testing.T, client HTTPClient, stream string, header map[string]string) {
@@ -573,7 +573,7 @@ func checkAPIAccess(t *testing.T, client HTTPClient, stream string, role string)
 
 func activateHotTier(t *testing.T) {
 	payload := StreamHotTier{
-		Size: fmt.Sprintf("%d", int64(20*math.Pow(1024, 3))), // set hot tier size to be 20 GB
+		Size: "20 GiB", // set hot tier size to be 20 GB
 	}
 	json, _ := json.Marshal(payload)
 

--- a/test_utils.go
+++ b/test_utils.go
@@ -567,8 +567,14 @@ func activateHotTier(t *testing.T) {
 	req, _ := NewGlob.QueryClient.NewRequest("PUT", "logstream/"+NewGlob.Stream+"/hottier", nil)
 	response, err := NewGlob.QueryClient.Do(req)
 	body := readAsString(response.Body)
-	require.Equalf(t, 200, response.StatusCode, "Server returned http code: %s and response: %s", response.Status, body)
-	require.NoErrorf(t, err, "Activating hot tier failed: %s", err)
+
+	if NewGlob.IngestorUrl.String() != "" {
+		require.Equalf(t, 200, response.StatusCode, "Server returned unexpected http code: %s and response: %s", response.Status, body)
+		require.NoErrorf(t, err, "Activating hot tier failed in distributed mode: %s", err)
+	} else {
+		// right now, hot tier is unavailable in standalone so anything other than 200 is fine
+		require.NotEqualf(t, 200, response.StatusCode, "Hot tier has been activated in standalone mode: %s and response: %s", response.Status, body)
+	}
 }
 
 func disableHotTier(t *testing.T) {

--- a/test_utils.go
+++ b/test_utils.go
@@ -245,7 +245,7 @@ func IngestOneEventForStaticSchemaStream_SameFieldsInLog(t *testing.T, client HT
 	require.Equalf(t, 200, response.StatusCode, "Server returned http code: %s resp %s", response.Status, readAsString(response.Body))
 }
 
-func QueryLogStreamCount(t *testing.T, client HTTPClient, stream string, count uint64) {
+func QueryLogStreamCount(t *testing.T, client HTTPClient, stream string, count uint64) string {
 	// Query last 30 minutes of data only
 	endTime := time.Now().Add(time.Second).Format(time.RFC3339Nano)
 	startTime := time.Now().Add(-30 * time.Minute).Format(time.RFC3339Nano)
@@ -263,6 +263,7 @@ func QueryLogStreamCount(t *testing.T, client HTTPClient, stream string, count u
 	require.Equalf(t, 200, response.StatusCode, "Server returned http code: %s and response: %s", response.Status, body)
 	expected := fmt.Sprintf(`[{"count":%d}]`, count)
 	require.Equalf(t, expected, body, "Query count incorrect; Expected %s, Actual %s", expected, body)
+	return body
 }
 
 func QueryLogStreamCount_Historical(t *testing.T, client HTTPClient, stream string, count uint64) {

--- a/test_utils.go
+++ b/test_utils.go
@@ -623,6 +623,7 @@ func getHotTierStatus(t *testing.T, shouldFail bool) *StreamHotTier {
 
 	if shouldFail {
 		require.NotEqualf(t, 200, response.StatusCode, "Hot tier was expected to fail but succeeded with body: %s", body)
+		return &StreamHotTier{Size: "0"}
 	} else {
 		require.Equalf(t, 200, response.StatusCode, "GET hot tier failed with status code: %d & body: %s", response.StatusCode, body)
 	}

--- a/test_utils.go
+++ b/test_utils.go
@@ -592,7 +592,7 @@ func activateHotTier(t *testing.T) {
 }
 
 func disableHotTier(t *testing.T) {
-	req, _ := NewGlob.QueryClient.NewRequest("PUT", "logstream/"+NewGlob.Stream+"/hottier", nil)
+	req, _ := NewGlob.QueryClient.NewRequest("DELETE", "logstream/"+NewGlob.Stream+"/hottier", nil)
 	response, err := NewGlob.QueryClient.Do(req)
 	body := readAsString(response.Body)
 	require.Equalf(t, 200, response.StatusCode, "Server returned http code: %s and response: %s", response.Status, body)


### PR DESCRIPTION
This PR adds test coverage for [Hot Tier](https://www.parseable.com/docs/features/tiering), which was added in [#852](https://github.com/parseablehq/parseable/pull/852). The following tests are being added:

## Endpoint tests
1. [x] **PUT** `/hottier` for standalone deployment - should fail, as hot tier is enabled only for distributed
2. [x] **PUT** `/hottier` for a stream which does not exist - should fail
3. [x] **PUT** `/hottier` for existing stream with time partition - should fail
4. [x] **PUT** `/hottier` for a stream with huge size (say 500 GB) - should fail because of validation failure, as disk usage should be below 80% of total disk space
5. [x] **PUT** `/hottier` for stream with existing hot tier - increase size, should be successful
6. [x] **PUT** `/hottier` for stream with existing hot tier - reduce size, should fail
7. [x] **GET** `/hottier` for a stream which does not exist
8. [x] **DELETE** `/hottier` for a stream which does not exist

## Logical tests
1. [x] create stream, ingest data for a duration, set hot tier, wait for 2-3 mins to see if all data is available in hot tier
2. [x] create stream, ingest data, query get count, set hot tier, wait for 2-3 mins, query again get count, both counts should match
3. [x] create stream, put hot tier, ingest data for a duration, wait for 2-3 mins to see if all data is available in hot tier
4. [ ] create stream, ingest data for a duration, call **GET** `/logstream/{logstream}/info` to get the `first_event_at` field. Then set hot tier, wait for 2-3 mins, call **GET** `/hottier` to get oldest entry in hot tier & assert both are equal.