### PR TITLE
rbac fixes as per server changes

### DIFF
--- a/quest_test.go
+++ b/quest_test.go
@@ -442,7 +442,6 @@ func TestSmokeRbacBasic(t *testing.T) {
 	checkAPIAccess(t, userClient, NewGlob.Stream, "editor")
 	DeleteUser(t, NewGlob.QueryClient, "dummy")
 	DeleteRole(t, NewGlob.QueryClient, "dummy")
-	DeleteStream(t, NewGlob.QueryClient, NewGlob.Stream)
 }
 
 func TestSmokeRoles(t *testing.T) {
@@ -452,8 +451,8 @@ func TestSmokeRoles(t *testing.T) {
 		body     string
 	}{
 		{
-			roleName: "editor",
-			body:     RoleEditor,
+			roleName: "ingestor",
+			body:     Roleingestor(NewGlob.Stream),
 		},
 		{
 			roleName: "reader",
@@ -464,8 +463,8 @@ func TestSmokeRoles(t *testing.T) {
 			body:     RoleWriter(NewGlob.Stream),
 		},
 		{
-			roleName: "ingestor",
-			body:     Roleingestor(NewGlob.Stream),
+			roleName: "editor",
+			body:     RoleEditor,
 		},
 	}
 
@@ -484,7 +483,7 @@ func TestSmokeRoles(t *testing.T) {
 			DeleteRole(t, NewGlob.QueryClient, tc.roleName)
 		})
 	}
-	DeleteStream(t, NewGlob.QueryClient, NewGlob.Stream)
+
 }
 
 func TestLoadStreamBatchWithK6(t *testing.T) {

--- a/test_utils.go
+++ b/test_utils.go
@@ -504,7 +504,7 @@ func checkAPIAccess(t *testing.T, client HTTPClient, stream string, role string)
 		req, _ = client.NewRequest("DELETE", "logstream/"+stream, nil)
 		response, err = client.Do(req)
 		require.NoErrorf(t, err, "Request failed: %s", err)
-		require.Equalf(t, 403, response.StatusCode, "Server returned http code: %s and response: %s", response.Status, readAsString(response.Body))
+		require.Equalf(t, 200, response.StatusCode, "Server returned http code: %s and response: %s", response.Status, readAsString(response.Body))
 
 	case "writer":
 		// Check access to non-protected API


### PR DESCRIPTION
1. editor has delete stream priviledge, hence delete stream API calls returns 200 instead of 403
2. changed order of role based tests in TestSmokeRoles such that ingestor can ingest 
but cannot delete the stream later editor can delete the stream
hence ingestor test happens first then the editor test in run