### PR TITLE
code for new alerts

### DIFF
--- a/test_utils.go
+++ b/test_utils.go
@@ -107,6 +107,13 @@ func DeleteStream(t *testing.T, client HTTPClient, stream string) {
 	require.Equalf(t, 200, response.StatusCode, "Server returned http code: %s", response.Status)
 }
 
+func DeleteAlert(t *testing.T, client HTTPClient, alert_id string) {
+	req, _ := client.NewRequest("DELETE", "alerts/"+alert_id, nil)
+	response, err := client.Do(req)
+	require.NoErrorf(t, err, "Request failed: %s", err)
+	require.Equalf(t, 200, response.StatusCode, "Server returned http code: %s", response.Status)
+}
+
 func RunFlog(t *testing.T, client HTTPClient, stream string) {
 	cmd := exec.Command("flog", "-f", "json", "-n", "50")
 	var out strings.Builder


### PR DESCRIPTION
PR contains modifications to quest for parseable's new alerts

`TestSmokeSetAlert` creates a new alert body using stream name

`TestSmokeGetAlert` fetches the new alert (GET returns a list of alerts), extracts `id`, `state` from the new alert, creates an alert response object by injecting `id`, `state`, `version` keys and matches with the response of `GET /alerts`

After matching, it deletes the alert using the `DeleteAlert` function 